### PR TITLE
keep opentelemetry state in trace_state_ptr

### DIFF
--- a/alternator/server.cc
+++ b/alternator/server.cc
@@ -343,7 +343,7 @@ static tracing::trace_state_ptr create_tracing_session(tracing::tracing& tracing
     tracing::trace_state_props_set props;
     props.set<tracing::trace_state_props::full_tracing>();
     props.set_if<tracing::trace_state_props::log_slow_query>(tracing_instance.slow_query_tracing_enabled());
-    return tracing_instance.create_session(tracing::trace_type::QUERY, props);
+    return tracing_instance.create_session(tracing::trace_type::QUERY, props, false);
 }
 
 // truncated_content_view() prints a potentially long chunked_content for

--- a/test/boost/tracing.cc
+++ b/test/boost/tracing.cc
@@ -62,7 +62,7 @@ SEASTAR_TEST_CASE(tracing_respect_events) {
         trace_props.set(tracing::trace_state_props::log_slow_query);
         trace_props.set(tracing::trace_state_props::full_tracing);
 
-        tracing::trace_state_ptr trace_state1 = t.create_session(tracing::trace_type::QUERY, trace_props);
+        tracing::trace_state_ptr trace_state1 = t.create_session(tracing::trace_type::QUERY, trace_props, false);
         tracing::begin(trace_state1, "begin", gms::inet_address());
 
         tracing::trace(trace_state1, "trace 1");
@@ -73,7 +73,7 @@ SEASTAR_TEST_CASE(tracing_respect_events) {
         t.set_ignore_trace_events(true);
         BOOST_CHECK(t.ignore_trace_events_enabled());
 
-        tracing::trace_state_ptr trace_state2 = t.create_session(tracing::trace_type::QUERY, trace_props);
+        tracing::trace_state_ptr trace_state2 = t.create_session(tracing::trace_type::QUERY, trace_props, false);
         tracing::begin(trace_state2, "begin", gms::inet_address());
 
         tracing::trace(trace_state2, "trace 1");
@@ -96,7 +96,7 @@ SEASTAR_TEST_CASE(tracing_slow_query_fast_mode) {
         tracing::trace_state_props_set trace_props;
         trace_props.set(tracing::trace_state_props::log_slow_query);
 
-        tracing::trace_state_ptr trace_state = t.create_session(tracing::trace_type::QUERY, trace_props);
+        tracing::trace_state_ptr trace_state = t.create_session(tracing::trace_type::QUERY, trace_props, false);
         tracing::begin(trace_state, "begin", gms::inet_address());
 
         // check no event created

--- a/tracing/trace_state.hh
+++ b/tracing/trace_state.hh
@@ -513,11 +513,11 @@ private:
 
 public:
     opentelemetry_state() = default;
-    opentelemetry_state(lw_shared_ptr<trace_state> state_ptr)
-        : _state_ptr(std::move(state_ptr))
+    opentelemetry_state(lw_shared_ptr<trace_state> state_ptr, bool opentelemetry_tracing = false)
+            : _state_ptr(std::move(state_ptr)), _opentelemetry_tracing(opentelemetry_tracing)
     {}
-    opentelemetry_state(std::nullptr_t)
-        : _state_ptr(nullptr)
+    opentelemetry_state(std::nullptr_t, bool opentelemetry_tracing = false)
+            : _state_ptr(nullptr), _opentelemetry_tracing(opentelemetry_tracing)
     {}
 
     /**

--- a/tracing/tracing.cc
+++ b/tracing/tracing.cc
@@ -115,7 +115,7 @@ future<> tracing::stop_tracing() {
     });
 }
 
-trace_state_ptr tracing::create_session(trace_type type, trace_state_props_set props) noexcept {
+trace_state_ptr tracing::create_session(trace_type type, trace_state_props_set props, bool opentelemetry_tracing) noexcept {
     if (!started()) {
         return nullptr;
     }
@@ -130,7 +130,7 @@ trace_state_ptr tracing::create_session(trace_type type, trace_state_props_set p
         props.set_if<trace_state_props::ignore_events>(!props.contains<trace_state_props::full_tracing>() && ignore_trace_events_enabled());
 
         ++_active_sessions;
-        return make_lw_shared<trace_state>(type, props);
+        return make_lw_shared<opentelemetry_state>(make_lw_shared<trace_state>(type, props), opentelemetry_tracing);
     } catch (...) {
         // return an uninitialized state in case of any error (OOM?)
         return nullptr;
@@ -149,7 +149,7 @@ trace_state_ptr tracing::create_session(const trace_info& secondary_session_info
         }
 
         ++_active_sessions;
-        return make_lw_shared<trace_state>(secondary_session_info);
+        return make_lw_shared<opentelemetry_state>(make_lw_shared<trace_state>(secondary_session_info));
     } catch (...) {
         // return an uninitialized state in case of any error (OOM?)
         return nullptr;

--- a/tracing/tracing.hh
+++ b/tracing/tracing.hh
@@ -485,10 +485,11 @@ public:
      *
      * @param type a tracing session type
      * @param props trace session properties set
+     * @param opentelemetry_tracing flag determining whether OpenTelemetry tracing is required
      *
      * @return tracing state handle
      */
-    trace_state_ptr create_session(trace_type type, trace_state_props_set props) noexcept;
+    trace_state_ptr create_session(trace_type type, trace_state_props_set props, bool opentelemetry_tracing) noexcept;
 
     /**
      * Create a new secondary tracing session.

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -385,8 +385,11 @@ future<foreign_ptr<std::unique_ptr<cql_server::response>>>
             cqlop == cql_binary_opcode::EXECUTE ||
             cqlop == cql_binary_opcode::BATCH) {
             trace_props.set_if<tracing::trace_state_props::write_on_close>(tracing_request == tracing_request_type::write_on_close);
-            trace_state = tracing::tracing::get_local_tracing_instance().create_session(tracing::trace_type::QUERY, trace_props);
+            trace_state = tracing::tracing::get_local_tracing_instance().create_session(tracing::trace_type::QUERY, trace_props, _server._query_processor.local().is_tracing_required());
         }
+    }
+    else if (_server._query_processor.local().is_tracing_required()) {
+        trace_state = tracing::trace_state_ptr{make_lw_shared<tracing::opentelemetry_state>(nullptr, true)};
     }
 
     tracing::set_request_size(trace_state, fbuf.bytes_left());


### PR DESCRIPTION
Depending on whether OpenTelemetry tracing and classic
tracing is requested, trace_state_ptr stores proper
values only for the fields that are necessary.